### PR TITLE
fixed selectors to not disable when rerender happens

### DIFF
--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -51,6 +51,7 @@ const hideFacility = (id)=>{
     const facilityTwo = document.getElementById("facility2")
     const facilityThree = document.getElementById("facility3")
     const facilityFour = document.getElementById("facility4")
+    
     switch (id){
         case 1:
             facilityOne.classList.remove("hidden")

--- a/scripts/FacilityMinerals.js
+++ b/scripts/FacilityMinerals.js
@@ -1,6 +1,6 @@
 import { foundFacilityMineral } from "./ChosenMinerals.js"
 import { getFacilitiesMinerals, getMiningFacilities, getMinerals, getChosenMinerals } from "./database.js"
-import { setJupitersArmId, setJupitersArmMineralId, setHermesArmpitId, setHermesArmpitMineralId, setHermesPalaceMineralId, setHermesPalaceId, setLilTayTaysId, setLilTayTaysMineralId } from "./database.js"
+import { setJupitersArmId, setJupitersArmMineralId, setHermesArmpitId, setHermesArmpitMineralId, setHermesPalaceMineralId, setHermesPalaceId, setLilTayTaysId, setLilTayTaysMineralId, setSelectedFacility } from "./database.js"
 
 document.addEventListener(
     "change",
@@ -10,6 +10,7 @@ document.addEventListener(
                     const [,targetId] = event.target.id.split("--")
                     setJupitersArmMineralId(parseInt(event.target.value))
                     setJupitersArmId(parseInt(targetId))
+                    setSelectedFacility(parseInt(targetId))
                     document.dispatchEvent(new CustomEvent ("stateChanged"))
                 }
         }
@@ -23,6 +24,7 @@ document.addEventListener(
                 const [,targetId] = event.target.id.split("--")
                 setLilTayTaysMineralId(parseInt(event.target.value))
                 setLilTayTaysId(parseInt(targetId))
+                setSelectedFacility(parseInt(targetId))
                 document.dispatchEvent(new CustomEvent ("stateChanged"))
                 }
         }
@@ -36,6 +38,7 @@ document.addEventListener(
                 const [,targetId] = event.target.id.split("--")
                 setHermesPalaceMineralId(parseInt(event.target.value))
                 setHermesPalaceId(parseInt(targetId))
+                setSelectedFacility(parseInt(targetId))
                 document.dispatchEvent(new CustomEvent ("stateChanged"))
             }
         }
@@ -49,6 +52,7 @@ document.addEventListener(
                 const [,targetId] = event.target.id.split("--")
                 setHermesArmpitMineralId(parseInt(event.target.value))
                 setHermesArmpitId(parseInt(targetId))
+                setSelectedFacility(parseInt(targetId))
                 document.dispatchEvent(new CustomEvent ("stateChanged"))
             }
         }
@@ -59,10 +63,16 @@ document.addEventListener(
 
 const minerals = getMinerals();
 export const jupitersArmMinerals = () =>{
-    let htmlString = `<ul class="hidden" id="facility1">`
+    let htmlString = ``
+    
     const allfacilityMinerals = getFacilitiesMinerals()
     const facility = getMiningFacilities().find((facility) => facility.name === "Jupiter's Arm")
     const facilityMinerals = allfacilityMinerals.filter((mineral) =>{return mineral.miningFacilityId === facility.id })
+    if (getChosenMinerals().facilityId === facility.id){
+        htmlString += `<ul class="" id="facility1">`
+    }else{
+        htmlString +=`<ul class="hidden" id="facility1">`
+    }
     for (const mineral of minerals){
         for (const facilityMineral of facilityMinerals){
             if (facilityMineral.mineralId === mineral.id){
@@ -78,9 +88,14 @@ export const jupitersArmMinerals = () =>{
     return htmlString
 }
 export const hermesArmpitMinerals = () =>{
-    let htmlString = `<ul class="hidden" id="facility2">`
+    let htmlString = ``
     const allfacilityMinerals = getFacilitiesMinerals()
     const facility = getMiningFacilities().find((facility) => facility.name === "Hermes' Armpit")
+    if (getChosenMinerals().facilityId === facility.id){
+        htmlString += `<ul class="" id="facility2">`
+    }else{
+        htmlString +=`<ul class="hidden" id="facility2">`
+    }
     const facilityMinerals = allfacilityMinerals.filter((mineral) =>{return mineral.miningFacilityId === facility.id })
     for (const mineral of minerals){
         for (const facilityMineral of facilityMinerals){
@@ -97,9 +112,14 @@ export const hermesArmpitMinerals = () =>{
     return htmlString
 }
 export const hermesPalaceMinerals = () =>{
-    let htmlString = `<ul class="hidden"id="facility3">`
+    let htmlString = ``
     const allfacilityMinerals = getFacilitiesMinerals()
     const facility = getMiningFacilities().find((facility) => facility.name === "Hermes' Palace")
+    if (getChosenMinerals().facilityId === facility.id){
+        htmlString += `<ul class="" id="facility3">`
+    }else{
+        htmlString +=`<ul class="hidden" id="facility3">`
+    }
     const facilityMinerals = allfacilityMinerals.filter((mineral) =>{return mineral.miningFacilityId === facility.id })
     for (const mineral of minerals){
         for (const facilityMineral of facilityMinerals){
@@ -116,9 +136,14 @@ export const hermesPalaceMinerals = () =>{
     return htmlString
 }
 export const lilTayTaysMinerals = () =>{
-    let htmlString = `<ul class="hidden"id="facility4">`
+    let htmlString = ``
     const allfacilityMinerals = getFacilitiesMinerals()
     const facility = getMiningFacilities().find((facility) => facility.name === "Lil' Tay-Tay's")
+    if (getChosenMinerals().facilityId === facility.id){
+        htmlString += `<ul class="" id="facility4">`
+    }else{
+        htmlString +=`<ul class="hidden" id="facility4">`
+    }
     const facilityMinerals = allfacilityMinerals.filter((mineral) =>{return mineral.miningFacilityId === facility.id })
     for (const mineral of minerals){
         for (const facilityMineral of facilityMinerals){


### PR DESCRIPTION
# Description

Changed the state of the list to generate after the html is rerendered to hold the value of the selected facility to determine which list should be hidden or displayed

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Test A- tried using event listener and the display function to fix this but it didnt work. Had to add a if statement on each facility that checked if the value of getChosenMinerals().facilityId was the same as the facility id of the list to display it.
- [ ] Test B

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
